### PR TITLE
feat: Implement --adv-link-mtu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage: uradvd [-h] -i <interface> -a/-p <prefix> [ -a/-p <prefix> ... ]
 [ --default-lifetime <seconds> ] [ --rdnss <ip> ... ]
 [ --valid-lifetime <seconds> ] [ --preferred-lifetime <seconds> ]
 [ --max-router-adv-interval <seconds> ] [ --min-router-adv-interval <seconds> ]
-[ --version ]
+[ --adv-link-mtu <bytes> ] [ --version ]
 ```
 
 * `-i <interface>`: interface to listen on (e.g. `eth0`)
@@ -19,6 +19,7 @@ Usage: uradvd [-h] -i <interface> -a/-p <prefix> [ -a/-p <prefix> ... ]
 * `--preferred-lifetime <seconds>`: The span of time during which the address can be freely used as a source and destination for traffic. Should be less or equal valid-lifetime. (default is `14400` seconds => 4h)
 * `--max-router-adv-interval <seconds>`: The maximum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds. (default is `600` seconds => 10m)
 * `--min-router-adv-interval <seconds>`: The minimum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds. (default is `200` seconds => 3m20s)
+* `--adv-link-mtu <bytes>`: The MTU option is used in RA messages to ensure that all nodes on a link use the same MTU value in those cases where the link MTU is not well known. (is omitted unless set)
 * `--version: Display the version number of the invoked uradvd.`
 
 This program is packaged for [OpenWrt](https://openwrt.org/) and [NixOS](https://nixos.org/).


### PR DESCRIPTION
> an option taking one argument: the MTU to advertise on the link
> 
> Must not be less than 1280 bytes.