### PR TITLE
fix: Utilize an apk compatible version format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -Wall -Wextra
-VERSION = r$(shell git rev-list --count HEAD)-$(shell git rev-parse --short=8 HEAD)
+VERSION = $(shell git rev-list --count HEAD)~$(shell git rev-parse --short=8 HEAD)
 
 all: uradvd
 uradvd: uradvd.o


### PR DESCRIPTION
as OpenWrt is our primary target and enforces:
- no leading characters
- no dashes (except the one delimiting package revisions)