### PR TITLE
Revert "fix: Utilize an apk compatible version format"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS += -Wall -Wextra
-VERSION = $(shell git rev-list --count HEAD)~$(shell git rev-parse --short=8 HEAD)
+VERSION = r$(shell git rev-list --count HEAD)-$(shell git rev-parse --short=8 HEAD)
 
 all: uradvd
 uradvd: uradvd.o


### PR DESCRIPTION
There is no reason for the version numbers shown by uradvd to cater to any specific packaging system.

This reverts commit 7e267a91b7e5b9d20557869c89a6d2bc5b64ec0c.