### PR TITLE
 feat: Implement --pref64 (RFC 8781)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Usage: uradvd [-h] -i <interface> -a/-p <prefix> [ -a/-p <prefix> ... ]
 [ --default-lifetime <seconds> ] [ --rdnss <ip> ... ]
 [ --valid-lifetime <seconds> ] [ --preferred-lifetime <seconds> ]
 [ --max-router-adv-interval <seconds> ] [ --min-router-adv-interval <seconds> ]
+[ --pref64 <prefix>/<len> ]
 [ --version ]
 ```
 
@@ -19,6 +20,7 @@ Usage: uradvd [-h] -i <interface> -a/-p <prefix> [ -a/-p <prefix> ... ]
 * `--preferred-lifetime <seconds>`: The span of time during which the address can be freely used as a source and destination for traffic. Should be less or equal valid-lifetime. (default is `14400` seconds => 4h)
 * `--max-router-adv-interval <seconds>`: The maximum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds. (default is `600` seconds => 10m)
 * `--min-router-adv-interval <seconds>`: The minimum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds. (default is `200` seconds => 3m20s)
+* `--pref64 <prefix>/<len>`: The NAT64 prefix used for IPv6 address synthesis by clients, as defined in RFC 8781, in CIDR notation.
 * `--version`: Display the version number of the invoked uradvd.
 
 This program is packaged for [OpenWrt](https://openwrt.org/) and [NixOS](https://nixos.org/).

--- a/uradvd.c
+++ b/uradvd.c
@@ -83,7 +83,7 @@ struct iface {
 	uint8_t mac[6];
 };
 
-struct __attribute__((__packed__)) nd_opt_rdnss {
+struct __attribute__((__packed__)) _nd_opt_rdnss {
 	uint8_t nd_opt_rdnss_type;
 	uint8_t nd_opt_rdnss_len;
 	uint16_t nd_opt_rdnss_reserved;
@@ -535,7 +535,7 @@ static void send_advert(void) {
 		};
 	}
 
-	struct nd_opt_rdnss rdnss = {};
+	struct _nd_opt_rdnss rdnss = {};
 	uint8_t rdnss_ips[G.n_rdnss][16];
 
 	if (G.n_rdnss > 0) {

--- a/uradvd.c
+++ b/uradvd.c
@@ -66,6 +66,7 @@ enum {
 	OPT_PREFERRED_LIFETIME,
 	OPT_MAX_ROUTER_ADV_INTERVAL,
 	OPT_MIN_ROUTER_ADV_INTERVAL,
+	OPT_PREF64,
 	OPT_VERSION,
 };
 
@@ -88,6 +89,13 @@ struct __attribute__((__packed__)) _nd_opt_rdnss {
 	uint8_t nd_opt_rdnss_len;
 	uint16_t nd_opt_rdnss_reserved;
 	uint32_t nd_opt_rdnss_lifetime;
+};
+
+struct __attribute__((__packed__)) _nd_opt_pref64 { /* RFC8781, Section 4 */
+	uint8_t nd_opt_pref64_type; /* Type 38 */
+	uint8_t nd_opt_pref64_len;
+	uint16_t nd_opt_pref64_scaled_lifetime_and_plc; /* 13 bits scaled lifetime in units of 8 seconds, 3 bits plc */
+	uint8_t nd_opt_pref64_prefix[12]; /* 96 bits */
 };
 
 static struct global {
@@ -115,6 +123,10 @@ static struct global {
 
 	size_t n_rdnss;
 	struct in6_addr rdnss[MAX_RDNSS];
+
+	bool pref64_enabled;
+	uint8_t pref64_prefix[12];
+	uint8_t pref64_plc;
 } G = {
 	.rtnl_sock = -1,
 	.icmp_sock = -1,
@@ -547,12 +559,30 @@ static void send_advert(void) {
 			memcpy(rdnss_ips[i], G.rdnss[i].s6_addr, 16);
 	}
 
+	struct _nd_opt_pref64 pref64 = {};
+
+	if (G.pref64_enabled) {
+		pref64.nd_opt_pref64_type = 38;
+		pref64.nd_opt_pref64_len = 2;
+		uint16_t scld_lifetime = (3u * G.max_rtr_adv_interval) / 8u; /* RFC8781 Section 4.1 */
+		if (scld_lifetime > 0x1FF) {
+			/* Safety check to ensure that the scaled lifetime fits into 13 bits.
+			   Can't be hit because the max_rtr_adv_interval is currently limited to 1800. */
+			scld_lifetime = 0x1FF;
+		}
+		pref64.nd_opt_pref64_scaled_lifetime_and_plc =
+			htons(scld_lifetime << 3 | (G.pref64_plc & 0x07));
+		memcpy(pref64.nd_opt_pref64_prefix, G.pref64_prefix, sizeof(G.pref64_prefix));
+	}
+
+
 	struct iovec vec[] = {
 		IOVEC(advert),
 		IOVEC(lladdr),
 		IOVEC(prefixes),
 		IOVEC_IF(G.n_rdnss > 0, rdnss),
 		IOVEC_IF(G.n_rdnss > 0, rdnss_ips),
+		IOVEC_IF(G.pref64_enabled, pref64),
 	};
 
 	struct sockaddr_in6 addr = {
@@ -600,6 +630,7 @@ static void usage(void) {
 			"[ --default-lifetime <seconds> ] [ --rdnss <ip> ... ]\n"
 			"[ --valid-lifetime <seconds> ] [ --preferred-lifetime <seconds> ]\n"
 			"[ --max-router-adv-interval <seconds> ] [ --min-router-adv-interval <seconds> ]\n"
+			"[ --pref64 <prefix>/<len> ]\n"
 			"[ --version ]\n");
 }
 
@@ -619,6 +650,69 @@ static void add_rdnss(const char *ip) {
 	}
 
 	G.n_rdnss++;
+}
+
+static void add_pref64(const char *prefix) {
+	const size_t len = strlen(prefix)+1;
+	char prefix2[len];
+	memcpy(prefix2, prefix, len);
+
+	char *slash = strchr(prefix2, '/');
+	if (!slash) {
+		fprintf(stderr, "uradvd: error: invalid PREF64, missing prefix size (in CIDR notation).\n");
+		exit(1);
+	}
+
+	*slash = 0;
+	const char *preflen_start = slash+1;
+	char *preflen_end;
+	ulong preflen = strtoul(preflen_start, &preflen_end, 0);
+	if (preflen_end == preflen_start || *preflen_end != '\0' || preflen > UINT8_MAX) {
+		fprintf(stderr, "uradvd: error: invalid PREF64 length %s (only prefixes of length 32, 40, 48, 56, 64 or 96 are supported).\n", preflen_start);
+		exit(1);
+	}
+	switch (preflen)
+	{
+	case 32:
+		G.pref64_plc = 5;
+		break;
+	case 40:
+		G.pref64_plc = 4;
+		break;
+	case 48:
+		G.pref64_plc = 3;
+		break;
+	case 56:
+		G.pref64_plc = 2;
+		break;
+	case 64:
+		G.pref64_plc = 1;
+		break;
+	case 96:
+		G.pref64_plc = 0;
+		break;
+
+	default:
+		fprintf(stderr, "uradvd: error: invalid PREF64 length %s (only prefixes of length 32, 40, 48, 56, 64 or 96 are supported).\n", preflen_start);
+		exit(1);
+		break;
+	}
+
+	struct in6_addr buf;
+	if (inet_pton(AF_INET6, prefix2, &buf) != 1) {
+		fprintf(stderr, "uradvd: error: invalid PREF64 %s.\n", prefix2);
+		exit(1);
+	}
+
+	/* Check that the host part is all-zeroes */
+	static const uint8_t zero[12] = {};
+	if (memcmp(buf.s6_addr + preflen/8, zero, (128-preflen)/8) != 0) {
+		fprintf(stderr, "uradvd: error: invalid PREF64 %s (host part is not all-zeroes).\n", prefix2);
+		exit(1);
+	}
+
+	memcpy(G.pref64_prefix, buf.s6_addr, 12);
+	G.pref64_enabled = true;
 }
 
 static void add_prefix(const char *prefix, bool adv_onlink) {
@@ -668,6 +762,7 @@ static void parse_cmdline(int argc, char *argv[]) {
 		[OPT_PREFERRED_LIFETIME] = {"preferred-lifetime", required_argument, 0, 0},
 		[OPT_MAX_ROUTER_ADV_INTERVAL] = {"max-router-adv-interval", required_argument, 0, 0},
 		[OPT_MIN_ROUTER_ADV_INTERVAL] = {"min-router-adv-interval", required_argument, 0, 0},
+		[OPT_PREF64] = {"pref64", required_argument, 0, 0},
 		[OPT_VERSION] = {"version", 0, 0, 0},
 		{0, 0, 0, 0}
 	};
@@ -730,6 +825,10 @@ static void parse_cmdline(int argc, char *argv[]) {
 
 				G.min_rtr_adv_interval = val;
 
+				break;
+
+			case OPT_PREF64:
+				add_pref64(optarg);
 				break;
 
 			case OPT_VERSION:


### PR DESCRIPTION
Hi! This implements the PREF64 option as defined in [RFC 8781](https://www.rfc-editor.org/rfc/rfc8781.html).
The background is that we want to do an IPv6-mostly Parker-based setup at FFMUC,  i.e. DNS64 + NAT64 + 464XLAT on clients and on nodes as fallback for clients that don't support CLAT on their own.
PREF64 helps clients to discover the NAT64 prefix for CLAT, especially useful in compination with the DHCP option 108 ("IPv6-only preferred") from [RFC 8925](https://www.rfc-editor.org/rfc/rfc8925.html)

---

The implementation should be relatively straightforward, adding the new `--pref64` option, to be used e.g. like `uradvd --pref64 64:ff9b::/96 -i eth0 -p 2001:db8::/64`.
The most "confusing" part I believe is the combined `nd_opt_pref64_scaled_lifetime_and_plc` ("scaled lifetime" plus "prefix length code"), as per the standard they are of length 13 bit and 3 bit respectively, which is quite annoying to handle given there's no arbitrary-sized integer <C23. to my knowledge In the end it's only one bitwise operation combining the two values into a common 16 bit int, though.

Note that I don't usually write any code in C, so please pay extra attention to things like safe string & memory handling during review, which I might or might not have gotten right. (I tried my best and followed existing code whenever possible)

~I was not able to test this with an actual client yet unfortunately, but at least Wireshark is able to parse the option correctly.~
Successfully tested with:
- an Android smartphone. To absolutely rule out that it could detect the prefix from any other source, I sent a different PREF64 than what is actually in use within the network and have also set a "Private DNS" server (aka DoT) that doesn't do DNS64.
  After reconnecting to the WiFi, Android started doing its own DNS64 + CLAT using the prefix from the PREF64 option.
- two Linux machines running a self-compiled [NetworkManager with CLAT support](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/2107) that fetches the prefix infromation from the PREF64 RA option

---

~I have also cherry-picked the `iovlen` change from #4 to base this option on the new mechanism - maybe you want to merge #4 first so I can rebase on top afterwards.~
~Now waiting for #11~